### PR TITLE
Feature/library updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2020.1.2"
+    id "edu.wpi.first.GradleRIO" version "2020.3.2"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.17.6",
+    "version": "5.18.2",
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
         "http://devsite.ctr-electronics.com/maven/release/"
@@ -11,19 +11,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.17.6"
+            "version": "5.18.2"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.17.6"
+            "version": "5.18.2"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -35,7 +35,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -47,7 +47,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -69,7 +69,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -83,7 +83,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -111,7 +111,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -125,7 +125,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixDiagnostics",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -139,7 +139,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCanutils",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -152,7 +152,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixPlatform",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -165,7 +165,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.6",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCore",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
# Summary 
Updated WPILib version to 2020.3.2, and CTRE Pheonix Library to 5.18.2

# Testing
I rebuilt the project successfully. No testing on the roboRio was performed.

# Risks and mitigations
The Talon FX/Falcon 500s need to be updated to firmware version 20.3.0.2 to be fully compatable with the new Phoenix library version. 

Once the robot project is update on your dev machine you will need to rebuild the project while connected to the internet.

The local WPILib tools (Shuffleboard, SmartDashboard, Outline viewer, etc...) may need to be updated on your local development machine as the 2020.3.2 update contained update to these tools.